### PR TITLE
LED点滅プログラムをgpiozero版(GPIO21)に更新

### DIFF
--- a/codes.json
+++ b/codes.json
@@ -3,18 +3,19 @@
     {
       "id": "led-blink",
       "title": "🔴 LED点滅プログラム",
-      "description": "基本的なLED制御プログラムです。GPIO18ピンに接続したLEDが1秒間隔で点滅します。",
+      "description": "基本的なLED制御プログラムです。gpiozeroライブラリを使い、GPIO21ピンに接続したLEDが1秒間隔で点滅します。",
       "difficulty": "初級",
       "tags": [
         "GPIO",
-        "LED"
+        "LED",
+        "gpiozero"
       ],
       "filename": "led_blink.py",
-      "code": "import RPi.GPIO as GPIO\nimport time\n\n# GPIOの設定\nGPIO.setmode(GPIO.BCM)\nGPIO.setup(18, GPIO.OUT)\n\nprint(\"LED点滅開始!Ctrl+Cで停止\")\n\ntry:\n    while True:\n        GPIO.output(18, GPIO.HIGH)  # LED点灯\n        print(\"LED ON\")\n        time.sleep(1)\n        \n        GPIO.output(18, GPIO.LOW)   # LED消灯\n        print(\"LED OFF\")\n        time.sleep(1)\n        \nexcept KeyboardInterrupt:\n    print(\"\\nプログラム停止\")\n    \nfinally:\n    GPIO.cleanup()  # GPIOをクリーンアップ\n    print(\"GPIO cleanup完了\")",
+      "code": "from gpiozero import LED\nfrom time import sleep\n\nled = LED(21)\n\nprint(\"LED点滅開始!Ctrl+Cで停止\")\ntry:\n    while True:\n        led.on()\n        print(\"LED ON\")\n        sleep(1)\n        \n        led.off()\n        print(\"LED OFF\")\n        sleep(1)\n        \nexcept KeyboardInterrupt:\n    print(\"\\nプログラム停止\")",
       "setup": {
-        "connection": "GPIO18 → LED+ → 抵抗(220Ω) → GND",
+        "connection": "GPIO21 → LED+ → 抵抗(220Ω) → GND",
         "command": "python3 led_blink.py",
-        "notes": ""
+        "notes": "ライブラリのインストール(ターミナルで実行)\npip install gpiozero lgpio --break-system-packages"
       }
     },
     {


### PR DESCRIPTION
`codes.json` の「🔴 LED点滅プログラム」(`led-blink`) を、`RPi.GPIO` 版から `gpiozero` 版に差し替えました。

## 変更内容

- **コード**: `gpiozero` の `LED(21)` を使ったシンプルな点滅プログラムに変更（`GPIO.cleanup()` 不要）
- **配線**: `GPIO18 → LED+ → 抵抗(220Ω) → GND` → `GPIO21 → LED+ → 抵抗(220Ω) → GND`（コードのピン番号に合わせて修正）
- **説明文**: gpiozero を使う旨と GPIO21 を明記
- **タグ**: `gpiozero` を追加
- **セットアップメモ**: これまで空欄だった `notes` に、事前に必要なインストールコマンドを追記

```
ライブラリのインストール(ターミナルで実行)
pip install gpiozero lgpio --break-system-packages
```

ファイル名 (`led_blink.py`) と実行コマンド (`python3 led_blink.py`) は変更していません。

---
_Generated by [Claude Code](https://claude.ai/code/session_015J9FWdpVJPwcveM51h3KUX)_